### PR TITLE
Makes indicators freeze when discord is not in focus

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,6 +93,7 @@ module.exports = class ChannelTyping extends Plugin {
           },
           React.createElement(Spinner, {
             type: 'pulsingEllipsis',
+            animated: document.hasFocus(),
             style: {
               marginLeft: 5,
               opacity: 0.7


### PR DESCRIPTION
This PR makes channel typing indicators freeze when discord isnt focused. This behavior more closely matches the behavior of the normal typing indicators under the message bar. Its a single line of code but it does all the work.