### PR TITLE
Add a classname to the indicator container

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,8 @@ module.exports = class ChannelTyping extends Plugin {
       : React.createElement(Tooltip,
         {
           position: 'top',
-          text: this._formatTyping(typing)
+          text: this._formatTyping(typing),
+          className: 'channel-typing'
         },
         React.createElement('div',
           {


### PR DESCRIPTION
Currently it's just a regular `<div>`.  It would be good to have a classname to refer to for styling and interoperability purposes.